### PR TITLE
build tools updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ npm-debug.log
 /dist
 **/*node_modules
 *.csproj
+/user-cu-build.config.js

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ gulp
 ```
 gulp build
 ```
+* server - load the `dist` folder into a local server to view in browser
+```
+gulp server
+# or to build & watch & run server
+gulp --server
+```
 
 
 ### Software Requirements

--- a/README.md
+++ b/README.md
@@ -1,44 +1,72 @@
 cu-patcher-ui
-=======
+=============
 
 > Camelot Unchained Patcher UI
 
 ---
 *Notice: This library is currently under heavy development and is not guaranteed to be in a working state as this time.  This notice will be removed when the library is stable.*
 
-
 Installation
----
-1. clone this repository
+------------
+##### 1. clone this repository
 ```
 git clone https://github.com/CUModSquad/cu-patcher-ui.git
 ```
-2. install npm packages
+##### 2. install npm packages
 ```
 npm install
 ```
 
+
 Build
----
-Gulp Tasks
-* default - build & watch directory for changes
+-----
+
+#### Gulp Tasks
+
+##### default
+*build & watch directory for changes*
 ```
 gulp
 ```
-* build - build the ui once
+##### build
+*build the ui once*
 ```
 gulp build
 ```
-* server - load the `dist` folder into a local server to view in browser
+
+##### server
+*load the `dist` folder into a local server to view in browser*
 ```
 gulp server
-# or to build & watch & run server
+```
+
+##### --server
+*run server command as part of default task*
+```
 gulp --server
 ```
 
+A full list of commands and arguments can be found **[here](https://github.com/csegames/cu-build-tools#modulelibrary---builder)**
 
-### Software Requirements
-* Git
-* NodeJs 4
-* NPM 3.3.x
+#### Changing Build & Publish Directories
 
+You can override the configuration specified in `cu-build.config.js` by creating a file called `user-cu-build.config.js`
+
+If you wanted to change the build directory from `dist` to `build` you could add the following to your user configuration:
+
+```js
+// add configuration here to override cu-build.config.js
+module.exports = {
+  bundle: {
+    dest: 'build'
+  }
+};
+
+```
+
+
+Software Requirements
+---------------------
+- Git
+- NodeJs 4
+- NPM 3.3.x

--- a/cu-build.config.js
+++ b/cu-build.config.js
@@ -7,7 +7,7 @@
 var name = 'cu-patcher-ui';
 
 module.exports = {
-  type: 'library',
+  type: 'module',
   path: __dirname,
   name: name,
   bundle: {

--- a/cu-build.config.js
+++ b/cu-build.config.js
@@ -6,7 +6,7 @@
 
 var name = 'cu-patcher-ui';
 
-module.exports = {
+var config = {
   type: 'module',
   path: __dirname,
   name: name,
@@ -17,3 +17,14 @@ module.exports = {
     ]
   }
 };
+
+// load user config and merge it with default config if it exists
+var extend = require('extend');
+var fs = require('fs');
+var userConfig = {};
+if (fs.existsSync(__dirname + '/user-cu-build.config.js')) {
+  userConfig = require(__dirname + '/user-cu-build.config.js');
+}
+config = extend(true, config, userConfig);
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "reflux-tsd": "github:saddieeiddas/reflux-tsd"
   },
   "devDependencies": {
-    "gulp": "^3.9.0",
-    "cu-build-tools": "latest"
+    "cu-build-tools": "latest",
+    "extend": "^3.0.0",
+    "gulp": "^3.9.0"
   }
 }


### PR DESCRIPTION
Have added a number of improvements for the build process:

---

##### Changed build type to `module`

This will prevent the `library` build from taking place

---

##### Documentation for Server Commands

Added information on how to run the local test server.

---

##### Ability to override Build Configuration

I have added the same system from `cu-ui` for overriding build configuration.

You can now create a file called `user-cu-build.config.js` where you can override any part of the build configuration.

Here is an example file, which would change the build directory:

```js
// user-cu-build.config.js
// add configuration here to override cu-build.config.js
module.exports = {
  bundle: {
    dest: 'my/new/build/folder'
  }
};
```

---
