### PR TITLE
Fix gulp server root 

### DIFF
--- a/cu-build.config.js
+++ b/cu-build.config.js
@@ -15,6 +15,9 @@ var config = {
       'src/**/!(*.js|*.jsx|*.ts|*.tsx|*.ui|*.styl|*.scss)',
       'src/include/**'
     ]
+  },
+  server: {
+    root: __dirname + "/publish/interface/cu-patcher-ui/"
   }
 };
 


### PR DESCRIPTION
for some reason started defaulting to dist folder after I pulled modsquad changes