### PR TITLE
Better text wrapping

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -226,7 +226,6 @@
           /* wrap at character level */
           overflow-wrap: break-word;
           white-space: pre-line;
-          word-break: break-all;
 
           .chat-line-nick {
             color: $chat-line-nick-color;


### PR DESCRIPTION
Don't break words unless there is no other option (ie still breaks very long words that wont fit on a single line).