### PR TITLE
Fix position of latency indicator, and lighten chat input placeholder

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -361,7 +361,7 @@
         }
 
         label {
-          color: #303030;
+          color: #909090;
         }
 
         label.active {
@@ -389,14 +389,14 @@
   .chat-disconnect {
     position: absolute;
     bottom: 0;
-    width: 70px;
+    width: 30px;
     height: 16px;
     opacity: 0.2;
     cursor: pointer;
     left: 0;
     text-align: center;
     color: white;
-    font-size: 10px;
+    font-size: 8px;
   }
 
 }


### PR DESCRIPTION
This is a re-submission of a previous fix, that unfortunately got overwritten by a subsequent PR.