### PR TITLE
Move latency indicator to better position

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -463,7 +463,7 @@
     height: 16px;
     opacity: 0.2;
     cursor: pointer;
-    left: 0;
+    left: 170px;
     text-align: center;
     color: white;
     font-size: 8px;


### PR DESCRIPTION
The recent drop of left margin means the latency indicator is now in an odd position, move it to somewhere vaguely sensible looking.