### PR TITLE
Move CSE icon just in front of nick rather than at beginning line

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -306,11 +306,12 @@
               content: "";
               background: url('../images/chat/chat-icon-cse.png') #2F2F2F;
               background-size: contain;
-              float: left;
               height: 20px;
               width: 20px;
-              display: block;
-              margin: 0px 5px 0px 0px;
+              display: inline-block;
+              margin: -6px 5px 0px -2px;
+              top: 6px;
+              position: relative;
             }
           }
           .chat-line-message {


### PR DESCRIPTION
#### For your consideration

The current cse-icon positioning places it at the beginning of the line, which is fine, when timestamps are turned off, but with timestamps turned on, I personally think it looks messy.

![Before Image](https://dl.dropboxusercontent.com/u/43876768/cse-icon.png)

This PR changes the style of the :before rule for the icon to use inline-block rather than float: left; to position the icon (with some jiggery-pokery to get the vertical alignment correct).

![After Image](https://dl.dropboxusercontent.com/u/43876768/cse-icon-4.png)