### PR TITLE
Move generation of HTML out into Emoji/Links modules.  

### DIFF
--- a/src/ts/content/chat/ChatLineParser.tsx
+++ b/src/ts/content/chat/ChatLineParser.tsx
@@ -7,73 +7,17 @@
 import * as React from 'react';
 import { ChatTextParser, ChatTextParserToken } from './ChatTextParser';
 import Emoji from './Emoji';
-import URLRegExp from './URLRegExp';
-import Whitelist from './URLWhitelist';
-
+import Links from './Links';
 import {prefixes, display} from './settings/chat-defaults';
 
 class ChatLineParser {
   _key: number = 0;
 
+  _showEmoticons: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.showEmoticons.key}`));
+
   static LINK: number = ChatTextParser.TEXT + 1;
   static EMOJI: number = ChatTextParser.TEXT + 2;
   
-  // Settings from Patcher Options
-  _embedImages: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.embedImages.key}`));
-  _embedVideos: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.embedVideos.key}`));
-  _showEmoticons: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.showEmoticons.key}`));
-
-  _fixupLink(url: string) : string {
-    if (url.indexOf('www.') == 0) {
-      url = 'http://' + url;
-    }
-    return url;
-  }
-
-  _parseLink(text: string) : JSX.Element[] {
-    const videoMatch: string = this._embedVideos ? Whitelist.isVideo(text) : null;
-    const vineMatch: string = this._embedVideos ? Whitelist.isVine(text) : null;
-    const href : string = this._fixupLink(text);
-
-    // Video link (youtube)
-    if (videoMatch) {
-      return [
-        <a key={this._key++} className="chat-line-message" target="_blank" href={href}>
-          <iframe className='chat-line-video' src={videoMatch} allowFullScreen></iframe>
-        </a>
-      ];
-    } 
-    
-    // Vine link (vine)
-    else if (vineMatch) {
-      return [
-        <a key={this._key++} className="chat-line-message" target="_blank" href={href}>
-          <iframe className='chat-line-vine' src={vineMatch}></iframe>
-          <script src="https://platform.vine.co/static/scripts/embed.js"></script>
-        </a>
-      ];
-    } 
-
-    // Image link (whitelisted)
-    else if (this._embedImages && Whitelist.isImage(text) && Whitelist.ok(text)) {
-      return [
-        <a key={this._key++} className="chat-line-message" target="_blank" href={href}>
-          <img className='chat-line-image' src={text} title={text}/>
-        </a>
-      ];
-    } 
-
-    // all other links
-    return [ <a key={this._key++} className="chat-line-message" target="_blank" href={href}>{text}</a> ];
-  }
-  
-  _parseEmoji(text: string) : JSX.Element[] {
-    const emoji : string = Emoji.fromText(text);
-    if (emoji) {
-      return [<span key={this._key++} className={'chat-emoticon emote-' + emoji}></span>];
-    }
-  }
-
   _parseText(text: string) : JSX.Element[] { 
     return [ <span key={this._key++} className="chat-line-message">{text}</span> ];
   }
@@ -90,8 +34,9 @@ class ChatLineParser {
   }
 
   parse(text: string): JSX.Element[] {
+    const keygen = () : number => { return this._key++; }; 
     const tokens : ChatTextParserToken[] = [
-      { token: ChatLineParser.LINK,  expr: URLRegExp.create() },      
+      { token: ChatLineParser.LINK,  expr: Links.createRegExp() },      
     ];
     if (this._showEmoticons) {
       tokens.push({ token: ChatLineParser.EMOJI, expr: Emoji.createRegExp() });
@@ -99,8 +44,8 @@ class ChatLineParser {
     const parser : ChatTextParser = new ChatTextParser(tokens);
     return parser.parse(text, (token: number, text: string) => {
       switch(token) {
-        case ChatLineParser.LINK:  return this._parseLink(text);
-        case ChatLineParser.EMOJI: return this._parseEmoji(text);
+        case ChatLineParser.LINK:  return Links.fromText(text, keygen);
+        case ChatLineParser.EMOJI: return Emoji.fromText(text, keygen);
       }
       // treat everything else as just text
       return this._parseText(text);

--- a/src/ts/content/chat/Emoji.tsx
+++ b/src/ts/content/chat/Emoji.tsx
@@ -4,7 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-function fromText(text:string): string {
+import * as React from 'react';
+
+function emojiNameFromText(text:string): string {
   switch(text) {
     case ':angry:': case ':[': case ':-[':
       return 'angry';
@@ -47,6 +49,13 @@ function fromText(text:string): string {
       return 'wondering';
   }
   return null;
+}
+
+function fromText(text: string, keygen: () => number) : JSX.Element[] {
+  const emoji : string = emojiNameFromText(text);
+  if (emoji) {
+    return [<span key={keygen()} className={'chat-emoticon emote-' + emoji}></span>];
+  }
 }
 
 function createRegExp() : RegExp {

--- a/src/ts/content/chat/Links.tsx
+++ b/src/ts/content/chat/Links.tsx
@@ -1,0 +1,66 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import * as React from 'react';
+import Whitelist from './URLWhitelist';
+import URLRegExp from './URLRegExp';
+import {prefixes, display} from './settings/chat-defaults';
+
+function _fixupLink(url: string) : string {
+  if (url.indexOf('www.') == 0) {
+    url = 'http://' + url;
+  }
+  return url;
+}
+
+function fromText(text: string, keygen:() => number) : JSX.Element[] {
+  const embedImages: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.embedImages.key}`));
+  const embedVideos: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.embedVideos.key}`));
+
+  const videoMatch: string = embedVideos ? Whitelist.isVideo(text) : null;
+  const vineMatch: string = embedVideos ? Whitelist.isVine(text) : null;
+  const href : string = _fixupLink(text);
+
+  // Video link (youtube)
+  if (videoMatch) {
+    return [
+      <a key={keygen()} className="chat-line-message" target="_blank" href={href}>
+        <iframe className='chat-line-video' src={videoMatch} allowFullScreen></iframe>
+      </a>
+    ];
+  } 
+  
+  // Vine link (vine)
+  else if (vineMatch) {
+    return [
+      <a key={keygen()} className="chat-line-message" target="_blank" href={href}>
+        <iframe className='chat-line-vine' src={vineMatch}></iframe>
+        <script src="https://platform.vine.co/static/scripts/embed.js"></script>
+      </a>
+    ];
+  } 
+
+  // Image link (whitelisted)
+  else if (embedImages && Whitelist.isImage(text) && Whitelist.ok(text)) {
+    return [
+      <a key={keygen()} className="chat-line-message" target="_blank" href={href}>
+        <img className='chat-line-image' src={text} title={text}/>
+      </a>
+    ];
+  } 
+
+  // all other links
+  return [ <a key={keygen()} className="chat-line-message" target="_blank" href={href}>{text}</a> ];
+}
+
+function createRegExp() : RegExp {
+  return URLRegExp.create();
+}
+
+export default {
+  fromText,
+  createRegExp
+}


### PR DESCRIPTION
This makes ChatLineParser a bit cleaner and leaves the detail of implementation of the various parsed entities up to the appropriate module.