### PR TITLE
Lazy load chat messages in scrollback buffer

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -289,6 +289,16 @@
           margin: 0.2em;
           opacity: 0.7;
           line-height: 1.3em;
+          
+          &.chat-lazyload {
+            /* This is an approximation only.  We don't actually know each */
+            /* line height, it varies depending on type of message and message */
+            /* content.  It doesn't really matter though.  21px is the height of */
+            /* a chat line that includes an emoji.  We just need something to */
+            /* make the user think he can keep scrolling back to trigger the */
+            /* lazy load. */
+            font-size: 21px;
+          }
 
           /* wrap at character level */
           overflow-wrap: break-word;

--- a/src/ts/content/chat/Chat.tsx
+++ b/src/ts/content/chat/Chat.tsx
@@ -108,6 +108,8 @@ class Chat extends React.Component<ChatProps, ChatState> {
 
   // Render chat
   render() {
+    const current : RoomId = this.state.chat.currentRoom;
+    const room : ChatRoomInfo = current ? this.state.chat.getRoom(current) : undefined;
     return (
       <div id={this.name} className="cse-chat chat-container no-select">
         <div className="chat-disconnect" onClick={this.disconnect}>{this.state.chat.latency}</div>
@@ -119,8 +121,7 @@ class Chat extends React.Component<ChatProps, ChatState> {
             leaveRoom={this.leaveRoom}
             />
           <Content
-            currentRoom={this.state.chat.currentRoom}
-            messages={this.state.chat.currentRoom ? this.getCurrentRoom().messages : undefined}
+            room={room}
             send={this.send}
             slashCommand={this.slashCommand}
             />

--- a/src/ts/content/chat/ChatRoomInfo.tsx
+++ b/src/ts/content/chat/ChatRoomInfo.tsx
@@ -19,8 +19,13 @@ class ChatRoomInfo {
   type: chatType;
   players: number = 0;
   unread: number = 0;
-  constructor(roomId: RoomId) {
+  scrollback: number = 0;
+  scrollbackPageSize: number;
+  scrollbackThreshold: number;
+  constructor(roomId: RoomId, scrollbackThreshold: number = 50, scrollbackPageSize: number = 50) {
     this.roomId = roomId;
+    this.scrollbackThreshold = scrollbackThreshold;
+    this.scrollbackPageSize = scrollbackPageSize;
   }
   public addUser(user: UserInfo) : void {
     this.users.push(<User key={this.key++} info={user}/>);
@@ -52,6 +57,23 @@ class ChatRoomInfo {
   }
   public seen() : void {
     this.unread = 0;
+  }
+  public startScrollback() : void {
+    if (this.messages.length > this.scrollbackThreshold) { 
+      this.scrollback = this.messages.length - this.scrollbackThreshold;
+    } else {
+      this.scrollback = 0;
+    }
+  }
+  public cancelScrollback() : void {
+    this.scrollback = 0;
+  }
+  public nextScrollbackPage() : void {
+    if (this.scrollbackPageSize > this.scrollback) {
+      this.cancelScrollback();
+    } else {
+      this.scrollback -= this.scrollbackPageSize;
+    }
   }
 }
 

--- a/src/ts/content/chat/ChatSession.tsx
+++ b/src/ts/content/chat/ChatSession.tsx
@@ -14,6 +14,9 @@ import ChatClient from '../../chat/ChatClient';
 import messageType from '../../chat/messageType';
 
 class ChatSession {
+  
+  SCROLLBACK_THRESHOLD : number = 50;
+  SCROLLBACK_PAGESIZE : number = 100;
 
   rooms: ChatRoomInfo[] = [];
   currentRoom: RoomId = undefined;
@@ -162,7 +165,7 @@ class ChatSession {
       // enter or leave
       if (type === messageType.AVAILIBLE) {
         room.addUser(user);
-        room.add(new ChatMessage(chatType.AVAILABLE, '', user.name));      
+        room.add(new ChatMessage(chatType.AVAILABLE, '', user.name));
       } else {
         room.removeUser(user);
         room.add(new ChatMessage(chatType.UNAVAILABLE, '', user.name));      
@@ -187,7 +190,11 @@ class ChatSession {
   getRoom(roomId: RoomId, add: boolean = true) : ChatRoomInfo {
     let room : ChatRoomInfo = this.findRoom(roomId);
     if (!room && add) {
-      room = new ChatRoomInfo(roomId);
+      room = new ChatRoomInfo(
+        roomId,
+        this.SCROLLBACK_THRESHOLD,
+        this.SCROLLBACK_PAGESIZE
+      );
       this.rooms.push(room);
     }
     return room;
@@ -219,7 +226,9 @@ class ChatSession {
     if (!this.findRoom(roomId)) {
       this.client.joinRoom(roomId.name);
     }
-    this.getRoom(roomId).seen();
+    const room: ChatRoomInfo = this.getRoom(roomId);
+    room.seen();
+    room.startScrollback();
     this.setCurrentRoom(roomId);
   }
 
@@ -237,6 +246,7 @@ class ChatSession {
       if (roomId.same(this.currentRoom)) {
         if (this.rooms.length) {
           this.currentRoom = this.rooms[0].roomId;
+          this.rooms[0].startScrollback();
         } else {
           this.currentRoom = undefined;
         }

--- a/src/ts/content/chat/ChatText.tsx
+++ b/src/ts/content/chat/ChatText.tsx
@@ -7,27 +7,34 @@
 import * as React from 'react';
 import ChatLine from './ChatLine';
 import RoomId from './RoomId';
+import ChatRoomInfo from './ChatRoomInfo';
 
 export class ChatTextState {
 }
 
 export interface ChatTextProps {
-  messages: JSX.Element[];
-  currentRoom: RoomId;
+  room: ChatRoomInfo;
 }
 
 const AUTOSCROLL_FUZZYNESS : number = 12;
 
 class ChatText extends React.Component<ChatTextProps, ChatTextState> {
+  SCROLLBACK_PAGESIZE: number = 50;
   scrollTop: number = undefined;
+  scrollPosFromBottom: number = undefined;
   currentRoom: RoomId = undefined;
   constructor(props: ChatTextProps) {
     super(props);
     this.state = new ChatTextState();
+    this.handleScroll = this.handleScroll.bind(this);
   }
   scroll() : void {
     const chatBox : any = this.refs['chatbox'];
-    if (chatBox.lastElementChild) {
+    if (this.scrollPosFromBottom) {
+      this.scrollTop = chatBox.scrollTop = chatBox.scrollHeight - this.scrollPosFromBottom;
+      this.scrollPosFromBottom = undefined;
+    }
+    else if (chatBox.lastElementChild) {
       if (this.scrollTop === undefined || (this.scrollTop - chatBox.scrollTop) <= AUTOSCROLL_FUZZYNESS) {
         chatBox.lastElementChild.scrollIntoView();
         this.scrollTop = chatBox.scrollTop;      
@@ -39,21 +46,55 @@ class ChatText extends React.Component<ChatTextProps, ChatTextState> {
   }
   componentDidMount() {
     this.scroll();
+    this.watchScroll();
+  }
+  componentWillUnmount() {
+    this.unwatchScroll();
+  }
+  watchScroll() {
+    const el: HTMLDivElement = this.refs['chatbox'] as HTMLDivElement;
+    el.addEventListener("scroll", this.handleScroll);
+  }
+  handleScroll(e: MouseEvent) {
+    const lazy: HTMLDivElement = this.refs['lazyload'] as HTMLDivElement;
+    if (lazy) {
+      const el: HTMLDivElement = this.refs['chatbox'] as HTMLDivElement;
+      if (el.scrollTop < lazy.offsetHeight) {
+        // lazy load rest of content
+        this.scrollPosFromBottom = el.scrollHeight - el.scrollTop;
+        this.props.room.nextScrollbackPage();
+        this.forceUpdate();
+      }
+    }
+  }
+  unwatchScroll() {
+    const el: HTMLElement = this.refs['chatbox'] as HTMLElement;
+    el.removeEventListener("scroll", this.handleScroll);
   }
   newRoom() : void {
-    this.currentRoom = this.props.currentRoom;
+    this.currentRoom = this.props.room.roomId;
     this.scrollTop = undefined;
   }
   render() {
+    const room : ChatRoomInfo = this.props.room;
+    let messages : JSX.Element[];
     let content : JSX.Element = undefined;
-    if (this.props.currentRoom) {
-      if (!this.currentRoom || !this.props.currentRoom.same(this.currentRoom)) {
+    let lazy : JSX.Element = undefined;
+    if (room) {
+      if (!this.currentRoom || !room.roomId.same(this.currentRoom)) {
         this.newRoom();
+      }
+      if (room.scrollback > 0) {
+        lazy = <div ref="lazyload" className="chat-lazyload" style={{ height: room.scrollback + 'em' }}></div>;
+      }
+      if (room.messages) {
+        messages = room.messages.slice(room.scrollback);
       }
     }
     return (
       <div ref="chatbox" className="chat-text allow-select-text">
-      {this.props.messages}
+      {lazy}
+      {messages}
       </div>
     );
   }

--- a/src/ts/content/chat/Content.tsx
+++ b/src/ts/content/chat/Content.tsx
@@ -8,27 +8,27 @@ import * as React from 'react';
 import ChatText from './ChatText';
 import ChatInput from './ChatInput';
 import ChatLine from './ChatLine';
+import ChatRoomInfo from './ChatRoomInfo';
 import { ChatMessage } from './ChatMessage';
 import RoomId from './RoomId';
 
 export interface ContentState {
 }
 export interface ContentProps {
-  messages: JSX.Element[];              // ChatLine elements to render
-  currentRoom: RoomId;                  // current room
+  room: ChatRoomInfo;                   // current room
   send: (roomId: RoomId, text: string) => void;
   slashCommand: (command: string) => void;
 }
 
 class Content extends React.Component<ContentProps, ContentState> {
   send = (text: string) : void => {
-    this.props.send(this.props.currentRoom, text);
+    this.props.send(this.props.room.roomId, text);
   }
   
   render() {
     return (
       <div className="chat-content">
-        <ChatText messages={this.props.messages} currentRoom={this.props.currentRoom}/>
+        <ChatText room={this.props.room}/>
         <ChatInput label="SEND" send={this.send} slashCommand={this.props.slashCommand}/>
       </div>
     );


### PR DESCRIPTION
This PR adds lazy loading chat history.  Initially only SCROLLBACK_THRESHOLD messages will be displayed when switching to a chat room.  A place-holder DIV is added to top of chat to approximate the physical size (lines) of chat that has not been loaded, so the scroll bar thumb looks vaguely sensible.  As the user scrolls the view and reaches this place-holder DIV, the next page (defined by SCROLLBACK_PAGESIZE) of messages are displayed along with a now smaller placeholder DIV.  The process repeats until all chat message history is loaded for the room.  Special care has been taken to ensure that the scrolling experience is smooth when scrolling back and lazy loading chat history.  The only noticeable effect is seen on the scroll bar, which may jump slightly and the thumb change size slightly during lazy loading.  This is due to the unpredictable size (height) of the chat about to be loaded and can't be helped.  The effect is minor however.