### PR TITLE
Fix NaN/max display in server listings.

### DIFF
--- a/src/ts/sidebar/ServerSelect.tsx
+++ b/src/ts/sidebar/ServerSelect.tsx
@@ -23,7 +23,7 @@ export interface ActiveServerViewProps {
 export interface ActiveServerViewState {};
 class ActiveServerView extends React.Component<ActiveServerViewProps, ActiveServerViewState> {
   render() {
-    let totalPlayers = this.props.item.arthurians + this.props.item.tuathaDeDanann + this.props.item.vikings;
+    let totalPlayers = (this.props.item.arthurians|0) + (this.props.item.tuathaDeDanann|0) + (this.props.item.vikings|0);
     let status = this.props.item.playerMaximum > 0 ? 'online' : 'offline';
     return (
       <div className='server-select quickselect-active'>
@@ -48,7 +48,7 @@ export interface ServerListViewProps {
 export interface ServerListViewState {};
 class ServerListView extends React.Component<ServerListViewProps, ServerListViewState> {
   render() {
-    let totalPlayers = this.props.item.arthurians + this.props.item.tuathaDeDanann + this.props.item.vikings;
+    let totalPlayers = (this.props.item.arthurians|0) + (this.props.item.tuathaDeDanann|0) + (this.props.item.vikings|0);
     let status = this.props.item.playerMaximum > 0 ? 'online' : 'offline';
     return (
       <div className='server-select quickselect-list'>


### PR DESCRIPTION
Not sure why Castle is returning no faction counts, but when they return undefined, the server listing is displaying NaN for the total player count.  This PR fixes that and assumes 0 players when its undefined.