### PR TITLE
Fix chat scrolling when join/parts are disabled.

### DIFF
--- a/src/ts/content/chat/Chat.tsx
+++ b/src/ts/content/chat/Chat.tsx
@@ -11,6 +11,7 @@ import ChatRoomInfo from './ChatRoomInfo';
 import { ChatMessage, chatType } from './ChatMessage';
 import SlashCommand from './SlashCommand';
 import RoomId from './RoomId';
+import { chatConfig, ChatConfig } from './ChatConfig';
 
 import Info from './Info';
 import Content from './Content';
@@ -19,6 +20,7 @@ import {initLocalStorage} from './settings/chat-defaults';
 export interface ChatState {
   chat: ChatSession;
   now: number;
+  config: ChatConfig;
 }
 
 export interface ChatProps {
@@ -34,8 +36,12 @@ class Chat extends React.Component<ChatProps, ChatState> {
     super(props);
     this.state = this.initialState();
 
+    // load configuration (before subscribing to options updates!)
+    chatConfig.refresh();
+
     // handle updates to chat session
     this._eventHandlers.push(events.on('chat-session-update', this.update));
+    this._eventHandlers.push(events.on('chat-options-update', this.optionsUpdated));
     
     // Initialize chat settings in localStorage
     initLocalStorage();
@@ -44,7 +50,8 @@ class Chat extends React.Component<ChatProps, ChatState> {
   initialState(): ChatState {
     return {
       chat: (window as any)['_cse_chat_session'] || new ChatSession(),
-      now: 0
+      now: 0,
+      config: chatConfig
     }
   }
 
@@ -67,6 +74,10 @@ class Chat extends React.Component<ChatProps, ChatState> {
 
   update = (chat : ChatSession) : void => {
     this.setState({ chat: chat, now: Date.now() } as any);
+  }
+  
+  optionsUpdated = (config: ChatConfig) : void => {
+    this.setState({ config: config, now: Date.now() } as any);
   }
   
   selectRoom = (roomId: RoomId) : void => {

--- a/src/ts/content/chat/ChatConfig.tsx
+++ b/src/ts/content/chat/ChatConfig.tsx
@@ -3,14 +3,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import {prefixes, display} from './settings/chat-defaults';
+import * as events from '../../core/events';
 
 export class ChatConfig {
   SCROLLBACK_BUFFER_SIZE: number = 1024;
+  SHOW_COLORS: boolean = false;
+  SHOW_EMOTICONS: boolean = false;
+  SHOW_MARKDOWN: boolean = false;
+  EMBED_IMAGES: boolean = false;
+  EMBED_VIDEOS: boolean = false;
+  JOIN_PARTS: boolean = false;
+  TIMESTAMPS: boolean = false;
   constructor() {
-    this.load();
+    this.refresh();
   }
-  load() : void {
-    // TODO : Waiting for patcher UI chat settings details
+  public refresh = () : void => {
+    const LOAD = (option: any) : any => {
+      return JSON.parse(localStorage.getItem(`${prefixes.display}${option.key}`));
+    }
+    this.SHOW_COLORS    = LOAD(display.showColors);
+    this.SHOW_EMOTICONS = LOAD(display.showEmoticons);
+    this.SHOW_MARKDOWN  = LOAD(display.showMarkdown);
+    this.EMBED_IMAGES   = LOAD(display.embedImages);
+    this.EMBED_VIDEOS   = LOAD(display.embedVideos);
+    this.JOIN_PARTS     = LOAD(display.joinParts);
+    this.TIMESTAMPS     = LOAD(display.timestamps);
+    events.fire('chat-options-update', this);
   }
 }
 

--- a/src/ts/content/chat/ChatLine.tsx
+++ b/src/ts/content/chat/ChatLine.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { chatType, ChatMessage } from './ChatMessage';
 import * as events from '../../core/events';
 import ChatLineParser from './ChatLineParser';
-import {prefixes, display} from './settings/chat-defaults';
+import { chatConfig } from './ChatConfig';
 
 export interface ChatLineState {
 }
@@ -50,13 +50,10 @@ class ChatLine extends React.Component<ChatLineProps, ChatLineState> {
   }
   render(): JSX.Element {
     let element: JSX.Element = null;
-    let showTimestamp = JSON.parse(localStorage.getItem(`${prefixes.display}${display.timestamps.key}`));
-    let timestamp : JSX.Element = showTimestamp ? <span className="chat-timestamp">{ this.timestamp(this.props.message) }</span> : null;
-
-    let joinParts = JSON.parse(localStorage.getItem(`${prefixes.display}${display.joinParts.key}`));
+    let timestamp : JSX.Element = chatConfig.TIMESTAMPS ? <span className="chat-timestamp">{ this.timestamp(this.props.message) }</span> : null;
     switch(this.props.message.type) {
       case chatType.AVAILABLE:
-        if (!joinParts) break;
+        if (!chatConfig.JOIN_PARTS) break;
         element = (
           <div className="chat-line">
             <span className="chat-line-entry">{this.props.message.nick} entered the room</span>
@@ -64,7 +61,7 @@ class ChatLine extends React.Component<ChatLineProps, ChatLineState> {
         );
         break;
       case chatType.UNAVAILABLE:
-        if (!joinParts) break;
+        if (!chatConfig.JOIN_PARTS) break;
         element = (
           <div className="chat-line">
             <span className="chat-line-exit">{this.props.message.nick} left the room</span>

--- a/src/ts/content/chat/ChatLineParser.tsx
+++ b/src/ts/content/chat/ChatLineParser.tsx
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 import { ChatTextParser, ChatTextParserToken } from './ChatTextParser';
-import {prefixes, display} from './settings/chat-defaults';
+import { chatConfig } from './ChatConfig';
 
 import Emoji from './Emoji';
 import Colors from './Colors';
@@ -15,11 +15,7 @@ import Markdown from './Markdown';
 
 class ChatLineParser {
   _key: number = 1;
-
-  _showColors: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.showColors.key}`));
-  _showEmoticons: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.showEmoticons.key}`));
-  _showMarkdown: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.showMarkdown.key}`));
-
+  
   static LINK: number = ChatTextParser.TEXT + 1;
   static EMOJI: number = ChatTextParser.TEXT + 2;
   static MARKDOWN: number = ChatTextParser.TEXT + 3;
@@ -44,15 +40,15 @@ class ChatLineParser {
     const keygen = () : number => { return this._key++; };
     const tokens : ChatTextParserToken[] = [];
     // Parsers which need recursion should be first
-    if (this._showColors) {
+    if (chatConfig.SHOW_COLORS) {
       tokens.push({ token: ChatLineParser.COLORS, expr: Colors.createRegExp() });
     }
-    if (this._showMarkdown) {
+    if (chatConfig.SHOW_MARKDOWN) {
       tokens.push({ token: ChatLineParser.MARKDOWN, expr: Markdown.createRegExp() });
     }
     // Parsers with simple search/replace should be last
     tokens.push({ token: ChatLineParser.LINK, expr: Links.createRegExp()} );
-    if (this._showEmoticons) {
+    if (chatConfig.SHOW_EMOTICONS) {
       tokens.push({ token: ChatLineParser.EMOJI, expr: Emoji.createRegExp() });
     }
     // Run through each parser

--- a/src/ts/content/chat/ChatRoomInfo.tsx
+++ b/src/ts/content/chat/ChatRoomInfo.tsx
@@ -27,11 +27,11 @@ class ChatRoomInfo {
     this.scrollbackThreshold = scrollbackThreshold;
     this.scrollbackPageSize = scrollbackPageSize;
   }
-  public addUser(user: UserInfo) : void {
+  public addUser = (user: UserInfo) : void => {
     this.users.push(<User key={this.key++} info={user}/>);
     this.players ++;
   }
-  public removeUser(user: UserInfo) : void {
+  public removeUser = (user: UserInfo) : void => {
     const users: JSX.Element[] = this.users;
     for (let i = 0; i < users.length; i++) {
       if (users[i].props.info.name === user.name) {
@@ -41,7 +41,7 @@ class ChatRoomInfo {
       }
     }
   }
-  public add(message: ChatMessage) : void {
+  public add = (message: ChatMessage) : void => {
     this.messages.push(
       <ChatLine key={this.key++} message={message}/>
     );
@@ -51,24 +51,37 @@ class ChatRoomInfo {
       this.messages.shift();
     }
   }
-  public push(message: ChatMessage) : void {
+  public push = (message: ChatMessage) : void => {
     this.add(message);
     this.unread ++;
   }
-  public seen() : void {
+  public seen = () : void => {
     this.unread = 0;
   }
-  public startScrollback() : void {
-    if (this.messages.length > this.scrollbackThreshold) { 
-      this.scrollback = this.messages.length - this.scrollbackThreshold;
+  public countVisibleMessages = () : number => {
+    let count: number = 0;
+    this.messages.forEach((message: JSX.Element) : void => {
+      if (!chatConfig.JOIN_PARTS) {
+        // not showing JOIN/PARTS so don't count these message types
+        if (message.props['message'].type === chatType.AVAILABLE) return;
+        if (message.props['message'].type === chatType.UNAVAILABLE) return;
+      }
+      count ++;      
+    });
+    return count;
+  }
+  public startScrollback = () : void => {
+    const count : number = this.countVisibleMessages();
+    if (count > this.scrollbackThreshold) { 
+      this.scrollback = count - this.scrollbackThreshold;
     } else {
       this.scrollback = 0;
     }
   }
-  public cancelScrollback() : void {
+  public cancelScrollback = () : void => {
     this.scrollback = 0;
   }
-  public nextScrollbackPage() : void {
+  public nextScrollbackPage = () : void => {
     if (this.scrollbackPageSize > this.scrollback) {
       this.cancelScrollback();
     } else {

--- a/src/ts/content/chat/Links.tsx
+++ b/src/ts/content/chat/Links.tsx
@@ -7,7 +7,7 @@
 import * as React from 'react';
 import Whitelist from './URLWhitelist';
 import URLRegExp from './URLRegExp';
-import {prefixes, display} from './settings/chat-defaults';
+import { chatConfig } from './ChatConfig';
 
 function _fixupLink(url: string) : string {
   if (url.indexOf('www.') == 0) {
@@ -17,11 +17,9 @@ function _fixupLink(url: string) : string {
 }
 
 function fromText(text: string, keygen:() => number) : JSX.Element[] {
-  const embedImages: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.embedImages.key}`));
-  const embedVideos: boolean = JSON.parse(localStorage.getItem(`${prefixes.display}${display.embedVideos.key}`));
 
-  const videoMatch: string = embedVideos ? Whitelist.isVideo(text) : null;
-  const vineMatch: string = embedVideos ? Whitelist.isVine(text) : null;
+  const videoMatch: string = chatConfig.EMBED_VIDEOS ? Whitelist.isVideo(text) : null;
+  const vineMatch: string = chatConfig.EMBED_VIDEOS ? Whitelist.isVine(text) : null;
   const href : string = _fixupLink(text);
 
   // Video link (youtube)
@@ -44,7 +42,7 @@ function fromText(text: string, keygen:() => number) : JSX.Element[] {
   } 
 
   // Image link (whitelisted)
-  else if (embedImages && Whitelist.isImage(text) && Whitelist.ok(text)) {
+  else if (chatConfig.EMBED_IMAGES && Whitelist.isImage(text) && Whitelist.ok(text)) {
     return [
       <a key={keygen()} className="chat-line-message" target="_blank" href={href}>
         <img className='chat-line-image' src={text} title={text}/>

--- a/src/ts/content/chat/settings/ChatDisplay.tsx
+++ b/src/ts/content/chat/settings/ChatDisplay.tsx
@@ -8,6 +8,8 @@ import * as React from 'react';
 import Prefixer from '../utils/Prefixer';
 import BooleanOption from './BooleanOption';
 import {display, prefixes} from './chat-defaults';
+import { chatConfig } from '../ChatConfig';
+
 const pre = new Prefixer(prefixes.display);
 
 export interface ChatDisplayProps {
@@ -41,6 +43,7 @@ class ChatDisplay extends React.Component<ChatDisplayProps, ChatDisplayState> {
 
   updateItem = (key: string, value: any) => {
     localStorage.setItem(pre.prefix(key), value);
+    chatConfig.refresh();
     this.setState(this.initializeState())
   }
 


### PR DESCRIPTION
This PR fixes an issue where when join/part messages are disabled, switching rooms does some funnies with the scroll bar.  This was happening because the lazy loading logic was not taking this option into account.

This PR also includes simpler access to config options.  Chat config options are now nicely wrapped in a ChatConfig class, of which there is a single instance.  This chat config is a cache of the localStorage options, and is refreshed whenever settings are changed and so is always up to date.  It removes the need to JSON parse content directly from localStorage to check an option.