### PR TITLE
Fix ParseRooms regex and pass regex results through parser.

### DIFF
--- a/src/ts/content/chat/ChatLineParser.tsx
+++ b/src/ts/content/chat/ChatLineParser.tsx
@@ -65,10 +65,10 @@ class ChatLineParser {
 
     // Run through each parser
     const parser : ChatTextParser = new ChatTextParser(tokens);
-    return parser.parse(text, (token: number, text: string) => {
+    return parser.parse(text, (token: number, text: string, match: RegExpExecArray) => {
       switch(token) {
-        case ChatLineParser.COLOR: return parseColors.fromText(text, keygen);
-        case ChatLineParser.MARKDOWN: return parseMarkdown.fromText(text, keygen);
+        case ChatLineParser.COLOR: return parseColors.fromText(text, keygen, match);
+        case ChatLineParser.MARKDOWN: return parseMarkdown.fromText(text, keygen, match);
         case ChatLineParser.LINK: return parseLinks.fromText(text, keygen);
         case ChatLineParser.ROOM: return parseRooms.fromText(text, keygen);
         case ChatLineParser.EMOJI: return parseEmoji.fromText(text, keygen);

--- a/src/ts/content/chat/ChatTextParser.tsx
+++ b/src/ts/content/chat/ChatTextParser.tsx
@@ -17,7 +17,7 @@ class ChatTextParser {
   constructor(tokens: ChatTextParserToken[]) {
     this.tokens = tokens;
   }
-  public parse(text: string, callback: (token: number, text: string) => JSX.Element[], index: number = 0): JSX.Element[] {
+  public parse(text: string, callback: (token: number, text: string, match: RegExpExecArray) => JSX.Element[], index: number = 0): JSX.Element[] {
     let html : JSX.Element[] = [];
     let insert : JSX.Element[];
     let section : string;
@@ -40,7 +40,7 @@ class ChatTextParser {
 
         // parse the match *only* if its not empty
         if (match[0]) {
-          insert = callback(this.tokens[index].token, match[0]);
+          insert = callback(this.tokens[index].token, match[0], match);
           if (!insert) {
             // text didn't match after all, parse again
             insert = this.parse(match[0], callback, index + 1);
@@ -66,7 +66,7 @@ class ChatTextParser {
     }
 
     // no more tokens, just treat as text
-    return callback(ChatTextParser.TEXT, text);
+    return callback(ChatTextParser.TEXT, text, null);
   }
 }
 

--- a/src/ts/content/chat/ParseColors.tsx
+++ b/src/ts/content/chat/ParseColors.tsx
@@ -8,18 +8,13 @@ import * as React from 'react';
 import ChatLineParser from './ChatLineParser';
 import { chatConfig } from './ChatConfig';
 
-function fromText(text: string, keygen: () => number) : JSX.Element[] {
-  const regexp: RegExp = this.createRegExp();
-  const match: RegExpExecArray = regexp.exec(text);
-
-  if (match) {
-    const matchColor: string = match[1];
-    const matchText: string = match[2];
-    if (chatConfig.SHOW_COLORS) {
-      return [<span key={keygen()} style={{ color: matchColor }}>{this.parse(matchText)}</span>];
-    } else {
-      return [<span key={keygen()}>{this.parse(matchText)}</span>];
-    }
+function fromText(text: string, keygen: () => number, match: RegExpExecArray) : JSX.Element[] {
+  const matchColor: string = match[1];
+  const matchText: string = match[2];
+  if (chatConfig.SHOW_COLORS) {
+    return [<span key={keygen()} style={{ color: matchColor }}>{this.parse(matchText)}</span>];
+  } else {
+    return [<span key={keygen()}>{this.parse(matchText)}</span>];
   }
 }
 

--- a/src/ts/content/chat/ParseMarkdown.tsx
+++ b/src/ts/content/chat/ParseMarkdown.tsx
@@ -8,10 +8,7 @@ import * as React from 'react';
 import ChatLineParser from './ChatLineParser';
 
 
-function fromText(text: string, keygen: () => number) : JSX.Element[] {
-  const regexp: RegExp = this.createRegExp();
-  const match: RegExpExecArray = regexp.exec(text);
-
+function fromText(text: string, keygen: () => number, match: RegExpExecArray) : JSX.Element[] {
   if (match && (match[2] || match[4])) {
     const matchBeginChar: string = match[1] ? match[1] : '';
     const matchEndChar: string = match[6] ? match[6] : '';

--- a/src/ts/content/chat/ParseRooms.tsx
+++ b/src/ts/content/chat/ParseRooms.tsx
@@ -12,7 +12,7 @@ function fromText(text: string, keygen: () => number) : JSX.Element[] {
 }
 
 function createRegExp() : RegExp {
-  return /#[^\s]+/g;
+  return /\B#[\S]+/g;
 }
 
 export default {


### PR DESCRIPTION
Better regular expression for parsing room names. This will prevent strings like "C#?" from being interpreted as a room name.

Also added Mehuge's suggestion for passing along the match results to prevent needing to run the regular expression twice for parsers like Colors and Markdown.