### PR TITLE
Bug Fix: Reset selections and spent attribute points on cancel character creation.

### DIFF
--- a/src/ts/character-creation/CharacterCreation.tsx
+++ b/src/ts/character-creation/CharacterCreation.tsx
@@ -112,7 +112,11 @@ class CharacterCreation extends React.Component<CharacterCreationProps, any> {
 
 
   componentWillMount() {
+    this.props.dispatch(resetAttributes());
     this.props.dispatch(resetCharacter());
+    this.props.dispatch(selectRace(null));
+    this.props.dispatch(selectGender(null));
+    this.props.dispatch(selectPlayerClass(null));
     this.props.dispatch(fetchFactions(this.props.apiHost, this.props.shard, this.props.apiVersion));
     this.props.dispatch(fetchRaces(this.props.apiHost, this.props.shard, this.props.apiVersion));
     this.props.dispatch(fetchPlayerClasses(this.props.apiHost, this.props.shard, this.props.apiVersion));


### PR DESCRIPTION
after cancelling a character creation then creating again without
closing the patcher, previous selections are not reset.

Attribute totals are reset / retrieved from the server, however your
available points to spend is not reset back to 30.