### PR TITLE
Set room button font size to 0.75em (ie 75% of normal)

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -398,7 +398,7 @@
             border: 1px #695D3F solid;
             background: #272213;
             padding: 0px 5px;
-            font-size: small;
+            font-size: 0.75em;
             transition: all .25s ease-in-out;
             &:hover {
               background-color: #584C2B;


### PR DESCRIPTION
Use 0.75em rather than small, as small renders differently on different machines.  0.75em chosen as it leaves enough space vertically between buttons without making the font too small to read, including the upcoming multiline text support (where vertical space between text is less than between separate chat messages)