### PR TITLE
Correct name of connectfailed event

### DIFF
--- a/src/ts/content/chat/ChatSession.tsx
+++ b/src/ts/content/chat/ChatSession.tsx
@@ -32,7 +32,7 @@ class ChatSession {
 
   constructor() {
       this.onconnect = this.onconnect.bind(this);
-      this.onconnectfail = this.onconnectfail.bind(this);
+      this.onconnectfailed = this.onconnectfailed.bind(this);
       this.onping = this.onping.bind(this);
       this.onchat = this.onchat.bind(this);
       this.ondisconnect = this.ondisconnect.bind(this);
@@ -66,7 +66,7 @@ class ChatSession {
     if (!this.client) {
       this.client = new ChatClient();
       this.client.on('connect', this.onconnect);
-      this.client.on('connectfail', this.onconnectfail);
+      this.client.on('connectfailed', this.onconnectfailed);
       this.client.on('ping', this.onping);
       this.client.on('presence', this.onchat);
       this.client.on('message', this.onchat);
@@ -97,11 +97,11 @@ class ChatSession {
     this.reconnecting = false;
   }
 
-  onconnectfail() {
+  onconnectfailed() {
     // if failed to connect and we are trying to re-connect, we should
     // retry
     if (this.reconnecting) {
-      // connectFail while reconnecting, try again
+      // connectFailed while reconnecting, try again
       this.reconnect();
     }
   }


### PR DESCRIPTION
I believe this is the reason auto-reconnect on connection failure is not working anymore.

The event fired by ChatClient is called 'connectfailed' but ChatSession was listening for 'connectfail'.

The connectFailed() method is the code that re-attempts the connection after a failed attempt to re-connect after a disconnect.