### PR TITLE
Show percentage on install / download progress

### DIFF
--- a/src/ts/sidebar/PatchButton.tsx
+++ b/src/ts/sidebar/PatchButton.tsx
@@ -238,12 +238,13 @@ class PatchButton extends React.Component<PatchButtonProps, PatchButtonState> {
         const remainingTime : number = percentDone ? ((100/percentDone)*downloadDuration) - downloadDuration : undefined;
         const time: string = percentDone ? Progress.secondsToString(remainingTime) : 'starting';
         const rate: string = Progress.bypsToString(downloadRate);
-        const dataSize: string  = Progress.bytesToString(estimate - downloadRemaining) + '/' + Progress.bytesToString(estimate);
+        const dataSize: string = Progress.bytesToString(estimate - downloadRemaining) + '/' + Progress.bytesToString(estimate);
+        const percentDisplay: string = percentDone ? '(' + Math.round(percentDone*100)/100.0 + '%)' : '';
         layer3 = (
           <div className='text'>
             <div className='progress-text'><span className='body'>{time}</span></div>
             <div className='progress-text'><span className='body'>{rate}</span></div>
-            <div className='progress-text'><span className='body'>{dataSize}</span></div>
+            <div className='progress-text'><span className='body'>{dataSize} {percentDisplay}</span></div>
           </div>
         );
         break;


### PR DESCRIPTION
Hi there, I have added the percentage display behind the file progress in layer3 mentioned on the trello board https://trello.com/c/kwdpq9EN/8-show-percentage-on-install-download-progress let me know what you think about. Its like **2.56GB/3.34GB (75.45%)**