### PR TITLE
second login attempt shows correct success now

### DIFF
--- a/src/ts/api/PatcherAPI.ts
+++ b/src/ts/api/PatcherAPI.ts
@@ -155,6 +155,7 @@ export class PatcherAPI {
     return this._api.completedFiles;
   }
   login(user :User) :void {
+    this._api.loginError = '';
     this._api.ValidateClient(user.email, user.password, user.rememberMe === true);
   }
   logout() :void {


### PR DESCRIPTION
Reported on the forums:

When you log in the Patcher with a wrong password, you get an error message. When you log in with the correct password afterwards, the same error message appears, but you are logged in then anyway.