### PR TITLE
Add options panel to manage chat room auto-joins.

### DIFF
--- a/src/sass/_chat.scss
+++ b/src/sass/_chat.scss
@@ -101,6 +101,7 @@
         min-width: 300px;
         z-index: 7;
         padding: 5px;
+        overflow-y: scroll;
 
         .row {
           border-bottom: 0.5px #333 solid;

--- a/src/ts/chat/ChatClient.tsx
+++ b/src/ts/chat/ChatClient.tsx
@@ -189,8 +189,6 @@ class ChatClient {
       return;
     }
     this.chat.joinRoom(roomName + this.chat.config.serviceAddress);
-
-    this.addToStoredRooms(roomName);
   }
 
   public leaveRoom(roomName: string): void {
@@ -199,8 +197,6 @@ class ChatClient {
       return;
     }
     this.chat.leaveRoom(roomName + this.chat.config.serviceAddress);
-
-    this.removeFromStoredRooms(roomName);
   }
 
   public getRooms() : void {

--- a/src/ts/chat/ChatClient.tsx
+++ b/src/ts/chat/ChatClient.tsx
@@ -82,6 +82,16 @@ class ChatClient {
     this.updated = Date.now();
   }
 
+  private _checkFirstTimeConfigs(): void {
+    if(localStorage.getItem("CSE_PATCHER_Stored_channels_init") === null){
+      localStorage.setItem("CSE_PATCHER_Stored_channels_init", 'true');
+      let rooms: string[] = DEFAULT_ROOM_LIST;
+      if (rooms.length > 0) {
+        localStorage.setItem("CSE_PATCHER_Stored_channels", rooms.toString());
+      }
+    }
+  }
+
   public on(topic: string, handler: (data?: any) => void): any {
     return this.emitter.on(topic, handler);
   }
@@ -94,7 +104,7 @@ class ChatClient {
     username: string | (() => string),
     password: string | (() => string),
     nick: string = "",
-    rooms: string[] = DEFAULT_ROOM_LIST
+    rooms: string[] = []
   ): void {
     if (this.chat) {
       console.warn("ChatClient:connect() called when already connected.");
@@ -104,6 +114,7 @@ class ChatClient {
     this.connected = false;
     this.updated = 0;
     this.config = new Config(username, password, nick);
+    this._checkFirstTimeConfigs();
     this._connect(rooms);
   }
 

--- a/src/ts/content/chat/Info.tsx
+++ b/src/ts/content/chat/Info.tsx
@@ -38,7 +38,7 @@ class Info extends React.Component<InfoProps, InfoState> {
     let content : JSX.Element[] = [];
     switch(this.state.currentTab) {
       case 'settings':
-        content.push(<Settings key='setings' />)
+        content.push(<Settings key='setings' getRooms={this.getRooms}/>)
         break;
       case 'users':
         content.push(<Users key="users" room={this.props.chat.getRoom(this.props.currentRoom)}/>);
@@ -46,7 +46,7 @@ class Info extends React.Component<InfoProps, InfoState> {
       case 'rooms': default:
         content.push(
           <Rooms
-            key="rooms" 
+            key="rooms"
             rooms={this.props.chat.rooms}
             current={this.props.currentRoom}
             select={this.props.selectRoom}

--- a/src/ts/content/chat/settings/ChatRooms.tsx
+++ b/src/ts/content/chat/settings/ChatRooms.tsx
@@ -5,36 +5,91 @@
  */
 
 import * as React from 'react';
-import Prefixer from '../utils/Prefixer';
-import {rooms, prefixes} from './chat-defaults';
-const pre = new Prefixer(prefixes.rooms);
+import * as events from '../../../core/events';
+import BooleanOption from './BooleanOption';
+import { Room } from '../../../chat/CSEChat';
+import ChatClient from '../../../chat/ChatClient';
 
 export interface ChatRoomsProps {
+  getRooms: () => void;
 }
 
 export interface ChatRoomsState {
-  rooms: Array<string>;
+  roomList: Room[];
+  roomsAutoJoin: string[];
 }
 
 class ChatRooms extends React.Component<ChatRoomsProps, ChatRoomsState> {
 
+  client: ChatClient = new ChatClient();
+
   constructor(props: ChatRoomsProps) {
     super(props);
     this.state = this.initializeState();
+    this.getRooms();
   }
-  
-  // initialize state from local storage
-  initializeState = (): ChatRoomsState =>  {
+
+  initializeState = (): ChatRoomsState => {
     let state: any = {};
-    let val = JSON.parse(localStorage.getItem(pre.prefix('autojoins')));
-    state.rooms = val == null ? rooms : val;
+    state.roomsAutoJoin = this.client.getStoredRooms();
+    state.roomList = [];
     return state;
   }
 
+  getRooms = (): void => {
+    events.once('chat-room-list', this.gotRooms);
+    this.props.getRooms();
+  }
+
+  gotRooms = (rooms: Room[]): void => {
+    rooms.forEach((room: any) => {
+      this.state.roomsAutoJoin.forEach((isAuto: string) => {
+        const tRoom: string = room.jid.split('@')[0];
+        room.displayName = tRoom;
+        if (tRoom == isAuto) {
+          room.autoJoin = true;
+        }
+      });
+    });
+    rooms = rooms.sort((a: any, b: any) => {
+      return (a.displayName < b.displayName) ? -1 : (a.displayName > b.displayName) ? 1 : 0;
+    });
+    this.setState({ roomList: rooms } as any);
+  }
+
+  generateBooleanOption = (option: any) => {
+    let state: any = this.state;
+    return <BooleanOption key={option.displayName}
+      optionKey={option.displayName}
+      title={option.displayName.length <= 15 ? option.displayName : option.displayName.substring(0, 15) + '...'}
+      description={option.name != option.displayName ? option.name : ''}
+      isChecked={option.autoJoin}
+      onChecked={this.updateItem}
+      />;
+  }
+
+  updateItem = (room: string, setAuto: any) => {
+    if (setAuto) {
+      this.client.addToStoredRooms(room);
+    }
+    else {
+      this.client.removeFromStoredRooms(room);
+    }
+  }
+
   render() {
+    let roomList: JSX.Element[] = [];
+    const rooms: any[] = this.state.roomList;
+    if (rooms.length) {
+      rooms.forEach((room: any, index: number) => {
+        roomList.push(this.generateBooleanOption(room));
+      });
+    }
+
     return (
       <div>
-        Hello from ChatRooms!
+        <h5>Autojoin Rooms:</h5>
+        {roomList}
       </div>
     )
   }

--- a/src/ts/content/chat/settings/Settings.tsx
+++ b/src/ts/content/chat/settings/Settings.tsx
@@ -10,9 +10,11 @@ let Animate = components.Animate;
 
 import BooleanOption from './BooleanOption';
 import ChatDisplay from './ChatDisplay';
+import ChatRooms from './ChatRooms';
 
 export interface SettingsProps {
-    key: string;
+  key: string;
+  getRooms: () => void;
 }
 
 export interface SettingsState {
@@ -22,7 +24,7 @@ export interface SettingsState {
 }
 
 class Settings extends React.Component<SettingsProps, SettingsState> {
-  
+
   constructor(props: SettingsProps) {
     super(props);
     this.state = {
@@ -31,12 +33,18 @@ class Settings extends React.Component<SettingsProps, SettingsState> {
       checked: true
     }
   }
-  
+
   generateSection = (sectionName: string) => {
-    if (sectionName == '') return null;
-    return <div key={sectionName} className='fly-out'><ChatDisplay /></div>
+    switch (sectionName) {
+      case 'chat-display':
+        return <div key={sectionName} className='fly-out'><ChatDisplay /></div>
+      case 'chat-rooms':
+        return <div key={sectionName} className='fly-out'><ChatRooms getRooms={this.props.getRooms}/></div>
+      default:
+        return null;
+    }
   }
-  
+
   navigate = (sectionName: string) => {
     let name = this.state.sectionName == sectionName ? '' : sectionName;
     this.setState({
@@ -45,7 +53,7 @@ class Settings extends React.Component<SettingsProps, SettingsState> {
       checked: this.state.checked
     });
   }
-  
+
   onChecked = (id: string) => {
     this.setState({
       section: this.state.section,
@@ -53,7 +61,7 @@ class Settings extends React.Component<SettingsProps, SettingsState> {
       checked: !this.state.checked
     });
   }
-  
+
   render() {
     let flyout = this.state.section;
     return (
@@ -63,7 +71,7 @@ class Settings extends React.Component<SettingsProps, SettingsState> {
             Chat Display<br />
             <i>Change what you see in the chatbox.</i>
           </li>
-          <li onClick={this.navigate.bind(this, '')} key={2}>
+          <li onClick={this.navigate.bind(this, 'chat-rooms')} key={2}>
             Rooms<br />
             <i>Available rooms &amp; autojoin settings.</i>
           </li>


### PR DESCRIPTION
Provides a listing of available chat rooms and allows users to select which rooms will be auto-joined when connecting to chat.

On first time connections, the default rooms will be added to the auto-join list, and then are managed through the auto-join settings as with any other room.

Room list is sorted alphabetically, ascending.

Changing an auto-join setting will not trigger an immediate join or leave. Settings are applied the next time chat is connected.

Joining or leaving a room during a session will no longer change auto-join rooms for the next session. All auto-join rooms are now managed through the options menu.