### PR TITLE
Add support npm run debug to compile to patcher UI folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ npm-debug.log
 /.vs
 /lib
 /dist
+/PatchClient
 **/*node_modules
 *.csproj
 /user-cu-build.config.js

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ npm run serve
 ### 5. Preview
 Navigate to http://localhost:9000
 
+### 6. Testing with Live Patcher
+1. Make a link (junction) named PatchClient in the local repository folder.
+
+      ```
+      C:
+      CD \path-to\your-git-clone
+      mklink /j PatchClient C:\path-to\game-install
+      ```
+
+2. Build the patcher using `````npm run debug````` to compile the UI and run it in the live patcher.
 
 Software Requirements
 ---------------------

--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
     "prebuild:nix": "npm run clean -s && npm run typings",
     "prebuild": "npm run clean -s && npm run typings",
     "publish": "npm run build",
-    "serve": "http-server -p 9000 dist/"
+    "serve": "http-server -p 9000 dist/",
+    "debug": "npm run build && npm run copy:patcher && npm run launch:patcher",
+    "copy:patcher": "(robocopy dist\\ PatchClient\\cpui\\UI /s ) ^& IF %ERRORLEVEL% LEQ 1 exit 0",
+    "launch:patcher": "cd Patchclient && start CamelotUnchained.exe canPatchSelf=0 outputUI=0"
   },
   "dependencies": {
     "camelot-unchained": "^0.2.17",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "tmp",
       "dist",
       "publish",
+      "PatchClient",
       "node_modules"
     ],
     "atom": {


### PR DESCRIPTION
Opening this PR in order to start a discussion on what should be the officially supported way of updating the cpui folder.  Seems we each have our own way of going about this, and this PR reflects the way I chose to do it (not saying its the best way, hence opening up the discussion).

What this PR now does is, it supports a folder (or junction/link) called PatchClient which can point at any client install (live or otherwise) and update and run that patcher with the compiled UI

    C:\GAMES\Camelot Unchained
    D:\DEV\CU\Mehuge\cu-patcher-ui\PatchClient -> (junction) -> C:\GAMES\Camelot Unchained

To build and run the patcher, use

    npm run debug

This builds the patcher and outputs to dist, as normal, then copies dist\* to PatchClient\cpui\UI ready for the patcher to be launched, then launches the patcher.